### PR TITLE
Updates boot-cljs and boot-reload to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pre-release software at the moment, you should do this frequently.
 In a terminal do:
 
 ```bash
-boot serve -d target/ watch speak reload cljs-repl cljs -usO none
+boot serve -d target/ watch speak reload cljs-repl cljs -sO none
 ```
 
 This builds a pipeline for your project:

--- a/build.boot
+++ b/build.boot
@@ -1,9 +1,9 @@
 (set-env!
  :source-paths   #{"src"}
  :resource-paths #{"html"}
- :dependencies '[[adzerk/boot-cljs      "0.0-2411-3" :scope "test"]
+ :dependencies '[[adzerk/boot-cljs      "0.0-2814-1" :scope "test"]
                  [adzerk/boot-cljs-repl "0.1.7"      :scope "test"]
-                 [adzerk/boot-reload    "0.2.0"      :scope "test"]
+                 [adzerk/boot-reload    "0.2.4"      :scope "test"]
                  [pandeiro/boot-http    "0.3.0"      :scope "test"]])
 
 (require


### PR DESCRIPTION
Example was broken due to https://github.com/adzerk/boot-reload/issues/8 which was fixed by updates to boot-cljs. This pull request uses the latest boot-cljs and works (before, the errors from the above issue would pop up).

In the latest version of boot-cljs, unified mode is the default and you actually can't pass `-u` to it anymore, so README is updated.